### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MuntasirSZN/csmc/security/code-scanning/4](https://github.com/MuntasirSZN/csmc/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow only performs linting and type-checking tasks, it does not require write permissions. The `contents: read` permission is sufficient for these operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
