### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unlighthouse.yml
+++ b/.github/workflows/unlighthouse.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/MuntasirSZN/csmc/security/code-scanning/3](https://github.com/MuntasirSZN/csmc/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `check` job. This block will explicitly define the minimal permissions required for the job to function. Based on the steps in the `check` job, it primarily interacts with the repository contents (e.g., checking out the code) and does not require write permissions. Therefore, we will set `contents: read` for the `check` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
